### PR TITLE
enable and fix gcc warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,11 @@ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package.])
 
 AM_GLIB_GNU_GETTEXT
 
+case "$CC" in
+  gcc*) CPPFLAGS="$CPPFLAGS -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers" ;;
+  *) ;;
+esac
+
 
 AC_CONFIG_FILES([
 	gtkballs.lsm

--- a/src/game.c
+++ b/src/game.c
@@ -174,7 +174,7 @@ gint rules_get_str_len(void) {
 gboolean rules_check_str(gchar *rstr) {
    GtkbGameRules r;
 
-   if (strlen(rstr) != _save_fmt_len ||
+   if (strlen(rstr) != (size_t) _save_fmt_len ||
        strstr(rstr, " ") ||
        strstr(rstr, "\t") ||
        strstr(rstr, "\r") ||

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -432,7 +432,7 @@ void move_ball(gint source_ball, gint target_ball)
    gint nodes[rules_get_width() * rules_get_height()];
    gint path[rules_get_width() * rules_get_height()];
    gint pawx = -1, pawy = -1;
-   gint i, j, k, phase, blah;
+   gint i, j, k, blah;
    gint x, y, color, tbx, tby, bc = board_get_at_node(_jumping_ball);
    gint direction, pawnum;
    gint *np = nodes;
@@ -451,7 +451,6 @@ void move_ball(gint source_ball, gint target_ball)
    find_x_y_of_the_node(&x, &y, source_ball, rules_get_width(), rules_get_height());
    color = board_get_at_node(source_ball);
    board_set_at_node(source_ball, 0);
-   phase = 0;
 
    draw_ball(0, x, y, 0, 0);
    if (pref_get_show_path())

--- a/src/halloffame.c
+++ b/src/halloffame.c
@@ -14,7 +14,7 @@
 void show_hall_of_fame (GtkWidget *widget, gpointer data, struct score_board b[10])
 {
    GtkWidget * dialog;
-   GtkWidget * frame, * sw, * tv;
+   GtkWidget * sw, * tv;
    GtkWidget * main_vbox, * vbox;
    gint i;
    struct score_board *bs = b;
@@ -73,7 +73,7 @@ void show_hall_of_fame (GtkWidget *widget, gpointer data, struct score_board b[1
    gtk_container_add(GTK_CONTAINER(sw), tv);
 
    if (data) {
-      str = g_strdup_printf("%u", (gint)data - 1);
+      str = g_strdup_printf("%u", GPOINTER_TO_INT (data) - 1);
       if ((path = gtk_tree_path_new_from_string(str))) {
          gtk_tree_selection_select_path(gtk_tree_view_get_selection(GTK_TREE_VIEW(tv)), path);
          gtk_tree_view_set_cursor(GTK_TREE_VIEW(tv), path, NULL, FALSE);

--- a/src/inputname.c
+++ b/src/inputname.c
@@ -16,7 +16,7 @@
 #include "halloffame.h"
 #include "game.h"
 
-static gchar _last_player_name[15] = "";
+static gchar _last_player_name[50] = "";
 static gint _saved_score = 0;
 
 static void read_entry (GtkEntry *entry, gpointer data)
@@ -31,25 +31,25 @@ static void read_entry (GtkEntry *entry, gpointer data)
    struct score_board_full *bf = NULL;
 
    tstr = (gchar*)gtk_entry_get_text (entry);
-   strncpy(current_entry.name, tstr && *tstr ? tstr : _("Anonymous"), sizeof(current_entry.name));
-   strncpy(_last_player_name, current_entry.name, sizeof(_last_player_name));
+   strncpy(current_entry.name, tstr && *tstr ? tstr : _("Anonymous"), sizeof(current_entry.name)-1);
+   strncpy(_last_player_name, current_entry.name, sizeof(_last_player_name)-1);
    current_entry.score = _saved_score;
    current_time = time(NULL);
    timeptr = localtime(&current_time);
 
    if (!timeptr) {
       ut_simple_message_box(_("Unable to determine current date.\n"));
-      strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date));
+      strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date)-1);
    } else {
       if (!strftime(current_entry.date, sizeof(current_entry.date), _("%a %b %d %H:%M %Y"), timeptr)) {
          ut_simple_message_box(_("Unable to determine current date.\n"));
-         strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date));
+         strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date)-1);
       } else {
          tstr = g_locale_to_utf8(current_entry.date, -1, &br, &bw, NULL);
          if (!tstr) {
-            strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date));
+            strncpy(current_entry.date, _("Unknown"), sizeof(current_entry.date)-1);
          } else {
-            strncpy(current_entry.date, tstr, sizeof(current_entry.date));
+            strncpy(current_entry.date, tstr, sizeof(current_entry.date)-1);
             g_free(tstr);
          }
       }
@@ -66,7 +66,7 @@ static void read_entry (GtkEntry *entry, gpointer data)
       free_score_board_full(bf, fbn);
       if (pos != -1) {
          pos++;
-         show_hall_of_fame(NULL, (gpointer)pos, b);
+         show_hall_of_fame(NULL, GINT_TO_POINTER (pos), b);
       }
    }
 
@@ -90,7 +90,6 @@ void input_name_dialog(void)
 {
    GtkWidget * dialog, * prompt_label, * vbox;
    GtkWidget * name;
-   GtkWidget * button;
    gchar * s;
 
    /* we have to save score, because they will be set to 0 in new_game() */
@@ -108,7 +107,7 @@ void input_name_dialog(void)
    /* restore the last player's name */
    if (!(*_last_player_name)) {
       if ((s = getenv("USER"))) {
-         strncpy(_last_player_name, s, sizeof(_last_player_name));
+         strncpy(_last_player_name, s, sizeof(_last_player_name)-1);
       }
    }
    gtk_entry_set_text(GTK_ENTRY(name), _last_player_name);

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -118,7 +118,7 @@ static void prefs_dialog_response (GtkDialog * dlg, int response, gpointer user_
 void preferences_dialog (void)
 {
    GtkWidget ** buttons;
-   GtkWidget * dialog, * frame;
+   GtkWidget * dialog;
    GtkWidget * big_vbox, * vbox;
    GtkWidget * theme_scrolled_window;
    gint i, st;

--- a/src/rules.c
+++ b/src/rules.c
@@ -16,7 +16,6 @@ void show_rules (GtkWidget *widget, gpointer data)
    GtkWidget * dialog;
    GtkWidget * main_vbox, * vbox, * hbox;
    GtkWidget * label;
-   GtkWidget * frame;
 
    dialog = gtkutil_dialog_new (_("Rules"), main_window, TRUE, &main_vbox);
    vbox   = gtkutil_frame_vbox (_("Rules"), main_vbox);

--- a/src/rulesdialog.c
+++ b/src/rulesdialog.c
@@ -62,9 +62,7 @@ static void rules_dialog_response (GtkDialog * dlg, int response, gpointer user_
 
 void rules_dialog (void)
 {
-   GtkWidget * dialog;
-   GtkWidget * frame;
-   GtkWidget * big_vbox, * vbox, * btn;
+   GtkWidget * dialog, * big_vbox, * vbox;
 
    dialog = gtkutil_dialog_new (_("Game rules"), main_window, TRUE, &big_vbox);
    vbox   = gtkutil_frame_vbox (_("Game rules"), big_vbox);

--- a/src/savedialog.c
+++ b/src/savedialog.c
@@ -161,7 +161,7 @@ gint game_compare_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, gpoi
    gtk_tree_model_get_value(model, a, 0, &value_a);
    gtk_tree_model_get_value(model, b, 0, &value_b);
    if ((str_a = (gchar *)g_value_get_string(&value_a)) && (str_b = (gchar *)g_value_get_string(&value_b))) {
-      for (i = 0; i < sizeof(sort_pos) / sizeof(gint); i++) {
+      for (i = 0; (size_t) i < sizeof(sort_pos) / sizeof(gint); i++) {
          if (str_a[sort_pos[i]] != str_b[sort_pos[i]]) {
             r = str_a[sort_pos[i]] < str_b[sort_pos[i]] ? 1 : -1;
             break;
@@ -207,7 +207,7 @@ void save_load_game_dialog(gboolean is_save)
    GtkCellRenderer * renderer;
    GtkTreeViewColumn * column;
    GtkTreePath * path;
-   GtkWidget * dialog, * swindow, * main_vbox, * vbox;
+   GtkWidget * dialog, * swindow, * vbox;
    gint      i, num;
    gchar     ** gamelist, str1[20], * str2;
 

--- a/src/savegame.c
+++ b/src/savegame.c
@@ -31,7 +31,7 @@ gint parse_save_game(gchar *sgame, gchar **rules, gint *score, gint **board, gin
 
    sdata = g_malloc(buf.st_size);
 
-   if (fread(sdata, 1, buf.st_size, f) != buf.st_size) {
+   if (fread(sdata, 1, buf.st_size, f) != (size_t) buf.st_size) {
       g_free (sdata);
       return 0;
    }

--- a/src/scoreboard.c
+++ b/src/scoreboard.c
@@ -161,13 +161,13 @@ gint read_score(struct score_board *b, struct score_board_full **bf, gint *nbf)
                   tstr = g_locale_to_utf8(str_val[0], -1, &br, &bw, NULL);
                }
                if (tstr) {
-                  strncpy(b[sc].name, tstr, sizeof(b[sc].name));
+                  strncpy(b[sc].name, tstr, sizeof(b[sc].name)-1);
                   g_free(tstr);
                } else {
-                  strncpy(b[sc].name, _("Unknown"), sizeof(b[sc].name));
+                  strncpy(b[sc].name, _("Unknown"), sizeof(b[sc].name)-1);
                }
                b[sc].score = strtol(str_val[1], NULL, 10);
-               if ((b[sc].score == LONG_MIN) || (b[sc].score == LONG_MAX)) {
+               if ((b[sc].score == INT_MIN) || (b[sc].score == INT_MAX)) {
                   b[sc].score = 0;
                }
                if (g_utf8_validate(str_val[2], -1, NULL)) {
@@ -176,20 +176,20 @@ gint read_score(struct score_board *b, struct score_board_full **bf, gint *nbf)
                   tstr = g_locale_to_utf8(str_val[2], -1, &br, &bw, NULL);
                }
                if (tstr) {
-                  strncpy(b[sc].date, tstr, sizeof(b[sc].date));
+                  strncpy(b[sc].date, tstr, sizeof(b[sc].date)-1);
                   g_free(tstr);
                } else {
-                  strncpy(b[sc].date, _("Unknown"), sizeof(b[sc].date));
+                  strncpy(b[sc].date, _("Unknown"), sizeof(b[sc].date)-1);
                }
                sc++;
             } else if (bf) {
                *bf = g_realloc(*bf, sizeof(struct score_board_full) * (fsc + 1));
-               strncpy((*bf)[fsc].name, str_val[0], sizeof((*bf)[fsc].name));
+               strncpy((*bf)[fsc].name, str_val[0], sizeof((*bf)[fsc].name)-1);
                (*bf)[fsc].score = strtol(str_val[1], NULL, 10);
-               if (((*bf)[fsc].score == LONG_MIN) || ((*bf)[fsc].score == LONG_MAX)) {
+               if (((*bf)[fsc].score == INT_MIN) || ((*bf)[fsc].score == INT_MAX)) {
                   (*bf)[fsc].score = 0;
                }
-               strncpy((*bf)[fsc].date, str_val[2], sizeof((*bf)[fsc].date));
+               strncpy((*bf)[fsc].date, str_val[2], sizeof((*bf)[fsc].date)-1);
                (*bf)[fsc].rules = g_strdup(g_rules);
                fsc++;
             }
@@ -227,8 +227,8 @@ gint insert_entry_in_score_board(struct score_board *board, struct score_board e
    }
 
    for (j = 8;j >= i; j--) {
-      strncpy(board[j + 1].name, board[j].name, sizeof(board[j + 1].name));
-      strncpy(board[j + 1].date, board[j].date, sizeof(board[j + 1].date));
+      strncpy(board[j + 1].name, board[j].name, sizeof(board[j + 1].name)-1);
+      strncpy(board[j + 1].date, board[j].date, sizeof(board[j + 1].date)-1);
       board[j + 1].score = board[j].score;
    }
 


### PR DESCRIPTION
in very recent distros there are warnings that can only be silenced with special gtk defines that will be applied once the code compiles without deprecations