### PR TITLE
add gtk3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,25 @@ This is the README for gtkballs.
 
 ## Requirements
 
- - a working X11 setup
- - gtk+ version 2.x
+ - GTK 2 >= 2.14 / GTK 3
 
 ## Compiling
 
-```
-$ ./autogen.sh
-$ ./configure
-$ make
-```
+Run
+
+- ./autogen.sh
+- ./configure --prefix=/usr
+- make
+
+By default the GTK3 port is compiled, use `--enable-gtk2`
+or `--disable-gtk3` to compile the GTK2 port.
+
+- ./configure --prefix=/usr --enable-gtk3
+
+The GTK3 version provides HiDPI support with:
+
+- `GDK_SCALE=2 ./gtkballs` - make UI 2x bigger
+- `GDK_SCALE=3 ./gtkballs` - make UI 3x bigger
 
 ## Installing
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,25 +18,48 @@ IT_PROG_INTLTOOL
 
 # Checks for programs.
 AC_PROG_CC
-AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/param.h signal.h])
 
-AC_ARG_ENABLE(gtk3,
-AS_HELP_STRING([--enable-gtk3],[enable to use gtk-3.0 instead of gtk-2.0]),
-[case "${enableval}" in
-  yes)  enable_gtk3=yes ;;
-  no)   enable_gtk3=no ;;
-esac],[])
+#========================================================================
 
-if test "x$enable_gtk3" = "xyes" ; then
-  gtk_modules="gtk+-3.0 >= 3.0.0"
-else
-  gtk_modules="gtk+-2.0 >= 2.14.0"
-  CPPFLAGS="$CPPFLAGS -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_SINGLE_INCLUDES -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES"
-fi
-PKG_CHECK_MODULES(GTK, [$gtk_modules])
-AC_SUBST(GTK_CFLAGS)
-AC_SUBST(GTK_LIBS)
+GTK3_CHECK="gtk+-3.0 >= 3.0.0"
+GTK2_CHECK="gtk+-2.0 >= 2.14.0"
+
+AC_ARG_ENABLE(gtk3,
+   AS_HELP_STRING([--disable-gtk3],[build with GTK3 (Autodetect)]),[],
+   [enable_gtk3=check])
+
+AC_ARG_ENABLE(gtk2,
+   AS_HELP_STRING([--enable-gtk2],[build with GTK2 (Autodetect)]),[],
+   [enable_gtk2=check])
+
+AS_IF([test "x$enable_gtk3" = xyes],
+   [enable_gtk2=no])
+AS_IF([test "x$enable_gtk2" = xyes],
+   [enable_gtk3=no])
+
+AS_IF([test "x$enable_gtk3" = xcheck],
+   [PKG_CHECK_MODULES([GTK],[$GTK3_CHECK],
+      [enable_gtk3=yes],[enable_gtk3=no])])
+
+AS_IF([test "x$enable_gtk3" = xyes],
+   [
+   gtk_modules="$GTK3_CHECK"
+   gtk_version="gtk+-3.0"
+   errmsg="GTK3 is not installed, use --enable-gtk2 to build with GTK2"
+   ],
+   [
+   gtk_modules="$GTK2_CHECK"
+   gtk_version="gtk+-2.0"
+   errmsg="GTK2 is not installed, use --enable-gtk3 to build with GTK3"
+   CPPFLAGS="$CPPFLAGS -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_SINGLE_INCLUDES -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES"
+   ])
+
+PKG_CHECK_MODULES([GTK], [$gtk_modules], [], [AC_ERROR([$errmsg])])
+AC_SUBST([GTK_CFLAGS])
+AC_SUBST([GTK_LIBS])
+
+#========================================================================
 
 GETTEXT_PACKAGE=gtkballs
 AC_SUBST(GETTEXT_PACKAGE)
@@ -61,3 +84,7 @@ AC_CONFIG_FILES([
 	gtkballs-data/Makefile
 ])
 AC_OUTPUT
+
+echo
+echo "GTK Version: $(pkg-config --modversion $gtk_version)"
+echo

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,20 @@ AC_PROG_CC
 AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/param.h signal.h])
 
-PKG_CHECK_MODULES(GTK, gtk+-2.0 >= 2.8)
+AC_ARG_ENABLE(gtk3,
+AS_HELP_STRING([--enable-gtk3],[enable to use gtk-3.0 instead of gtk-2.0]),
+[case "${enableval}" in
+  yes)  enable_gtk3=yes ;;
+  no)   enable_gtk3=no ;;
+esac],[])
+
+if test "x$enable_gtk3" = "xyes" ; then
+  gtk_modules="gtk+-3.0 >= 3.0.0"
+else
+  gtk_modules="gtk+-2.0 >= 2.14.0"
+  CPPFLAGS="$CPPFLAGS -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_SINGLE_INCLUDES -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES"
+fi
+PKG_CHECK_MODULES(GTK, [$gtk_modules])
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)
 

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -355,14 +355,21 @@ void draw_next_balls(void) {
 }
 
 /* Refill the screen from the backing pixmap */
-gint expose_event (GtkWidget *widget, GdkEventExpose *event)
+gboolean boardw_draw_event (GtkWidget *widget, gpointer compat, gpointer data)
 {
+#if GTK_MAJOR_VERSION >= 3
+   cairo_t * cr = (cairo_t *) compat;
+   GdkRectangle rect;
+   GdkRectangle * area = &rect;
+   gdk_cairo_get_clip_rectangle (cr, area);
+#else // gtk2, espose_ event
+   GdkEventExpose * event = (GdkEventExpose *) compat;
    cairo_t * cr = gdk_cairo_create (gtk_widget_get_window (widget));
    GdkRectangle * area = &(event->area);
+#endif
 
-   GtkAllocation a;
-   gtk_widget_get_allocation (widget, &a);
-   if (area->width == a.width) {
+   int width = gtk_widget_get_allocated_width (widget);
+   if (area->width == width) {
       cairo_set_source_surface (cr, pixsurf, 0, 0);
       cairo_paint (cr);
    } else {
@@ -373,7 +380,10 @@ gint expose_event (GtkWidget *widget, GdkEventExpose *event)
       cairo_fill (cr);
       //cairo_restore (cr);
    }
+
+#if GTK_MAJOR_VERSION == 2
    cairo_destroy (cr);
+#endif
    return FALSE;
 }
 

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -18,7 +18,7 @@ void redraw_ball(gint x, gint y);
 void redraw_pointer(void);
 void draw_board(void);
 /* Refill the screen from the backing pixmap */
-gint expose_event(GtkWidget *widget, GdkEventExpose *event);
+gboolean boardw_draw_event (GtkWidget *widget, gpointer compat, gpointer data);
 void remake_board(gint numoldchilds, gboolean isnextvalid);
 
 void reinit_board(gint *newboard, gint *newnext, gint score, gint oldnext);

--- a/src/gtkballs.h
+++ b/src/gtkballs.h
@@ -2,6 +2,7 @@
 #define __GTKBALLS__H
 
 #include <config.h>
+#include "gtkcompat.h"
 
 extern GtkWindow * main_window;
 

--- a/src/gtkcompat.h
+++ b/src/gtkcompat.h
@@ -1,0 +1,559 @@
+/*
+ * This is free and unencumbered software released into the public domain.
+ *
+ * For more information, please refer to <https://unlicense.org>
+ */
+
+/** 2021-01-21 **/
+
+/*
+ * gtkcompat.h, GTK2+ compatibility layer
+ * 
+ * This lib makes it easier to support older GTK versions
+ * while still avoiding deprecated functions as much as possible.
+ * 
+ * The older the GTK version, the more compatible functions are "defined"
+ * so it's not wise to use the compiled binary in newer distros or something.
+ * 
+ * Apps should support gtk2 >= 2.14 / gtk3 >= 3.14
+ * 
+ */
+
+/* 
+special defines:
+	gtkcompat_widget_set_halign_left   (w)
+	gtkcompat_widget_set_halign_center (w)
+	gtkcompat_widget_set_halign_right  (w)
+*/
+
+/*
+GTKCOMPAT_DRAW_SIGNAL (gtk3="draw", gtk2="expose_event")
+---------------------
+ g_signal_connect (w, GTKCOMPAT_DRAW_SIGNAL, G_CALLBACK (w_draw_cb), NULL);
+ gboolean w_draw_cb (GtkWidget *w, gpointer compat, gpointer user_data)
+ {
+ #if GTK_CHECK_VERSION (3, 0, 0)
+    cairo_t * cr = (cairo_t *) compat;
+ #else // gtk2
+    //GdkEventExpose * event = (GdkEventExpose *) compat;
+    cairo_t * cr = gdk_cairo_create (gtk_widget_get_window (w));
+ #endif
+ #if GTK_MAJOR_VERSION == 2
+    cairo_destroy (cr);
+ #endif
+ }
+*/
+
+#ifndef __GTKCOMPAT_H
+#define __GTKCOMPAT_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+
+#if GTK_MAJOR_VERSION == 3
+#include <gdk/gdkkeysyms-compat.h>
+#endif
+
+
+/* ================================================== */
+/*                      GLIB                          */
+/* ================================================== */
+
+#ifndef __GLIB_COMPAT_H
+#define __GLIB_COMPAT_H
+
+#include <glib.h>
+
+// GLIB < 2.58
+#if ! GLIB_CHECK_VERSION (2, 58, 0)
+#define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+#endif
+
+
+// GLIB < 2.40
+#if ! GLIB_CHECK_VERSION (2, 40, 0)
+#define g_key_file_save_to_file(kfile,filename,error) { \
+   char * data = g_key_file_to_data (kfile, NULL, error); \
+   g_file_set_contents (filename, data, -1, error); \
+   g_free (data); \
+}
+#endif
+
+
+// GLIB < 2.32
+#if ! GLIB_CHECK_VERSION (2, 32, 0)
+#define G_SOURCE_REMOVE   FALSE
+#define G_SOURCE_CONTINUE TRUE
+#define GRecMutex              GStaticRecMutex
+#define g_rec_mutex_init(x)    g_static_rec_mutex_init(x)
+#define g_rec_mutex_lock(x)    g_static_rec_mutex_lock(x)
+#define g_rec_mutex_trylock(x) g_static_rec_mutex_trylock(x)
+#define g_rec_mutex_unlock(x)  g_static_rec_mutex_unlock(x)
+#define g_rec_mutex_clear(x)   g_static_rec_mutex_free(x)
+#define g_thread_new(name,func,data) g_thread_create(func,data,TRUE,NULL)
+#define g_thread_try_new(name,func,data,error) g_thread_create(func,data,TRUE,error)
+#define g_hash_table_add(ht,key)      g_hash_table_replace(ht,key,key)
+#define g_hash_table_contains(ht,key) g_hash_table_lookup_extended(ht,key,NULL,NULL)
+#endif
+
+
+// GMutex vs GStaticMutex
+#if GLIB_CHECK_VERSION (2, 32, 0)
+// since version 2.32.0 GMutex can be statically allocated
+// don't use WGMutex to replace GMutex * ... issues, errors.
+#	define WGMutex GMutex
+#	define Wg_mutex_init    g_mutex_init
+#	define Wg_mutex_lock    g_mutex_lock
+#	define Wg_mutex_trylock g_mutex_trylock
+#	define Wg_mutex_unlock  g_mutex_unlock
+#	define Wg_mutex_clear   g_mutex_clear
+#else
+#	define WGMutex GStaticMutex
+#	define Wg_mutex_init    g_static_mutex_init
+#	define Wg_mutex_lock    g_static_mutex_lock
+#	define Wg_mutex_trylock g_static_mutex_trylock
+#	define Wg_mutex_unlock  g_static_mutex_unlock
+#	define Wg_mutex_clear   g_static_mutex_free
+// sed -i 's%g_mutex_%Wg_mutex_%g' $(grep "g_mutex_" *.c *.h | cut -f 1 -d ":" | grep -v -E 'gtkcompat|glib-compat' | sort -u)
+#endif
+
+
+// GLIB < 2.30
+#if ! GLIB_CHECK_VERSION (2, 30, 0)
+#define g_format_size g_format_size_for_display
+#endif
+
+
+// GLIB < 2.28
+#if ! GLIB_CHECK_VERSION (2, 28, 0)
+#define g_list_free_full(list,free_func) {\
+     g_list_foreach (list, (GFunc) free_func, NULL);\
+     g_list_free (list);\
+}
+#endif
+
+
+// GLIB < 2.22
+#if ! GLIB_CHECK_VERSION (2, 22, 0)
+#define g_mapped_file_unref(x) g_mapped_file_free(x)
+#endif
+
+// GLIB < 2.20
+#if ! GLIB_CHECK_VERSION (2, 20, 0)
+#define g_app_info_get_commandline(app) g_app_info_get_executable(app)
+#endif
+
+/* glib 2.18+ tested */
+
+#endif /* __GLIB_COMPAT_H */
+
+
+
+/* ================================================== */
+/*                       GTK                          */
+/* ================================================== */
+
+// STOCK items work in GTK2/3 but not in GTK4
+#if GTK_MAJOR_VERSION >= 4
+#define GTKCOMPAT_STOCK_OK     "_OK"
+#define GTKCOMPAT_STOCK_CANCEL "_Cancel"
+#define GTKCOMPAT_STOCK_APPLY  "_Apply"
+#define GTKCOMPAT_STOCK_CLOSE  "_Close"
+#define GTKCOMPAT_STOCK_YES    "_Yes"
+#define GTKCOMPAT_STOCK_NO     "_No"
+#define GTKCOMPAT_STOCK_SAVE   "_Save"
+#define GTKCOMPAT_STOCK_QUIT   "_Quit"
+#define GTKCOMPAT_STOCK_OPEN   "_Open"
+#define GTKCOMPAT_STOCK_ABOUT  "_About"
+#else
+#define GTKCOMPAT_STOCK_OK     "gtk-ok"
+#define GTKCOMPAT_STOCK_CANCEL "gtk-cancel"
+#define GTKCOMPAT_STOCK_APPLY  "gtk-apply"
+#define GTKCOMPAT_STOCK_CLOSE  "gtk-close"
+#define GTKCOMPAT_STOCK_YES    "gtk-yes"
+#define GTKCOMPAT_STOCK_NO     "gtk-no"
+#define GTKCOMPAT_STOCK_SAVE   "gtk-save"
+#define GTKCOMPAT_STOCK_QUIT   "gtk-quit"
+#define GTKCOMPAT_STOCK_OPEN   "gtk-open"
+#define GTKCOMPAT_STOCK_ABOUT  "gtk-about"
+#endif
+
+
+/* ================================================== */
+/*                       GTK 3                        */
+/* ================================================== */
+
+// GTK >= 3.0 -- applies to GTK3, GTK4...
+#if GTK_MAJOR_VERSION >= 3
+#define GTKCOMPAT_DRAW_SIGNAL "draw"
+#define gtkcompat_widget_set_halign_left(w)   gtk_widget_set_halign(GTK_WIDGET(w), GTK_ALIGN_START)
+#define gtkcompat_widget_set_halign_center(w) gtk_widget_set_halign(GTK_WIDGET(w), GTK_ALIGN_CENTER)
+#define gtkcompat_widget_set_halign_right(w)  gtk_widget_set_halign(GTK_WIDGET(w), GTK_ALIGN_END)
+#endif
+
+
+// GTK < 3.12
+#if ! GTK_CHECK_VERSION (3, 12, 0)
+#define gtk_widget_set_margin_start(widget,margin) gtk_widget_set_margin_left(widget,margin)
+#define gtk_widget_set_margin_end(widget,margin)   gtk_widget_set_margin_right(widget,margin)
+#endif
+
+
+// GTK < 3.10 && GTK >= 2.22
+#if (! GTK_CHECK_VERSION (3, 10, 0)) && (GTK_CHECK_VERSION (2, 22, 0))
+#define gdk_window_create_similar_image_surface(gdksurf,format,width,height,scale) \
+        (gdk_window_create_similar_surface(gdksurf,CAIRO_CONTENT_COLOR_ALPHA,width,height))
+#endif
+
+
+// GTK < 3.8
+#if ! GTK_CHECK_VERSION (3, 8, 0)
+#define gtk_widget_set_opacity(w,o) gtk_window_set_opacity(GTK_WINDOW(w),o)
+#define gtk_widget_get_opacity(w)  (gtk_window_get_opacity(GTK_WINDOW(w))
+#endif
+
+
+// GTK < 3.4
+#if ! GTK_CHECK_VERSION (3, 4, 0)
+#define gtk_application_window_new(app) gtk_window_new(GTK_WINDOW_TOPLEVEL)
+#endif
+
+
+
+/* ================================================== */
+/*                       GTK 2                        */
+/* ================================================== */
+
+// define some GTK3+ functions
+#if GTK_MAJOR_VERSION <= 2
+#define GTKCOMPAT_DRAW_SIGNAL "expose_event"
+#define gtk_box_new(ori,spacing) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hbox_new(FALSE,spacing) \
+                                       : gtk_vbox_new(FALSE,spacing))
+#define gtk_button_box_new(ori) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hbutton_box_new() \
+                                       : gtk_vbutton_box_new())
+#define gtk_scale_new(ori,adjustment) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hscale_new(adjustment) \
+                                       : gtk_vscale_new(adjustment))
+#define gtk_scale_new_with_range(ori,min,max,step) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hscale_new_with_range(min,max,step) \
+                                       : gtk_vscale_new_with_range(min,max,step))
+#define gtk_separator_new(ori) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hseparator_new() \
+                                       : gtk_vseparator_new())
+#define gtk_scrollbar_new(ori,adjustment) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hscrollbar_new(adjustment) \
+                                       : gtk_vscrollbar_new(adjustment))
+#define gtk_paned_new(ori) \
+  ((ori == GTK_ORIENTATION_HORIZONTAL) ? gtk_hpaned_new() \
+                                       : gtk_vpaned_new())
+#define gtk_widget_get_allocated_height(widget) (GTK_WIDGET(widget)->allocation.height )
+#define gtk_widget_get_allocated_width(widget)  (GTK_WIDGET(widget)->allocation.width  )
+#define gtk_combo_box_text_remove_all(cmb) { \
+   gtk_list_store_clear (GTK_LIST_STORE (gtk_combo_box_get_model (GTK_COMBO_BOX (cmb)))); \
+}
+#define gtk_tree_model_iter_previous(model,iter) ({ \
+   GtkTreePath * path = gtk_tree_model_get_path (model, iter); \
+   gboolean valid = gtk_tree_path_prev (path); \
+   if (valid) gtk_tree_model_get_iter (model, iter, path); \
+   gtk_tree_path_free (path); \
+   valid; \
+})
+#define gtk_widget_override_font(w,f) gtk_widget_modify_font(w,f)
+#define gtkcompat_widget_set_halign_left(w)   gtk_misc_set_alignment(GTK_MISC(w), 0.0, 0.5)
+#define gtkcompat_widget_set_halign_center(w) gtk_misc_set_alignment(GTK_MISC(w), 0.5, 0.5)
+#define gtkcompat_widget_set_halign_right(w)  gtk_misc_set_alignment(GTK_MISC(w), 1.0, 0.5)
+/* GtkApplication */
+#define GtkApplication void
+#define g_application_quit(app) gtk_main_quit()
+#undef G_APPLICATION
+#define G_APPLICATION(app) ((void *) (app))
+#endif
+
+
+// GTK < 2.24
+#if ! GTK_CHECK_VERSION (2, 24, 0)
+typedef struct _GtkComboBox        GtkComboBoxText;
+typedef struct _GtkComboBoxClass   GtkComboBoxTextClass;
+typedef struct _GtkComboBoxPrivate GtkComboBoxTextPrivate;
+#define GTK_TYPE_COMBO_BOX_TEXT            (gtk_combo_box_get_type ())
+#define GTK_COMBO_BOX_TEXT(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_COMBO_BOX, GtkComboBoxText))
+#define GTK_COMBO_BOX_TEXT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), GTK_TYPE_COMBO_BOX, GtkComboBoxTextClass))
+#define GTK_IS_COMBO_BOX_TEXT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GTK_TYPE_COMBO_BOX))
+#define GTK_IS_COMBO_BOX_TEXT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), GTK_TYPE_COMBO_BOX))
+#define GTK_COMBO_BOX_TEXT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), GTK_TYPE_COMBO_BOX, GtkComboBoxTextClass))
+#define gtk_combo_box_text_new() gtk_combo_box_new_text()
+#define gtk_combo_box_text_new_with_entry()	gtk_combo_box_entry_new_text()
+#define gtk_combo_box_text_append_text(combo,text) gtk_combo_box_append_text(combo,text)
+#define gtk_combo_box_text_insert_text(combo,pos,text) gtk_combo_box_insert_text(combo,pos,text)
+#define gtk_combo_box_text_prepend_text(combo,text) gtk_combo_box_prepend_text(combo,text)
+#define gtk_combo_box_text_remove(combo,pos) gtk_combo_box_remove_text(combo,pos)
+#define gtk_combo_box_text_get_active_text(combo) (gtk_combo_box_get_active_text(combo))
+#define gtk_combo_box_get_has_entry(combo) (0)
+#define gtk_combo_box_set_entry_text_column(combo,cl)
+#define gtk_combo_box_get_entry_text_column(combo) (0)
+#define gtk_range_get_round_digits(range) (GTK_RANGE(range)->round_digits)
+//#define gdk_window_get_visual(w)  (gdk_drawable_get_visual(GDK_DRAWABLE(w)))
+#define gdk_window_get_screen(w)  (gdk_drawable_get_screen(GDK_DRAWABLE(w)))
+#define gdk_window_get_display(w) (gdk_drawable_get_display(GDK_DRAWABLE(w)))
+#define gtk_notebook_get_group_name gtk_notebook_get_group
+#define gtk_notebook_set_group_name gtk_notebook_set_group
+#endif
+
+
+// GTK < 2.22
+#if ! GTK_CHECK_VERSION (2, 22, 0)
+#define gtk_window_has_group(w) (GTK_WINDOW(w)->group != NULL)
+#define gtk_window_group_get_current_grab(wg) \
+  ((GTK_WINDOW_GROUP(wg)->grabs) ? GTK_WIDGET(GTK_WINDOW_GROUP(wg)->grabs->data) : NULL)
+#define gtk_font_selection_dialog_get_font_selection(fsd)(GTK_FONT_SELECTION_DIALOG(fsd)->fontsel)
+#define gtk_notebook_get_tab_hborder(n) (GTK_NOTEBOOK(n)->tab_hborder)
+#define gtk_notebook_get_tab_vborder(n) (GTK_NOTEBOOK(n)->tab_vborder)
+#define gtk_button_get_event_window(button) (GTK_BUTTON(button)->event_window)
+#define gdk_visual_get_visual_type(visual) (GDK_VISUAL(visual)->type)
+#define gdk_visual_get_depth(visual) (GDK_VISUAL(visual)->depth)
+#define gdk_visual_get_byte_order(visual) (GDK_VISUAL(visual)->byte_order)
+#define gdk_visual_get_colormap_size(visual) (GDK_VISUAL(visual)->colormap_size)
+#define gdk_visual_get_bits_per_rgb(visual) (GDK_VISUAL(visual)->bits_per_rgb)
+#define gtk_icon_view_get_item_orientation gtk_icon_view_get_orientation
+#define gtk_icon_view_set_item_orientation gtk_icon_view_set_orientation
+#define gdk_window_create_similar_surface(gdksurf,content,width,height) ({ \
+   cairo_t * wcr = gdk_cairo_create (gdksurf); \
+   cairo_surface_t * window_surface = cairo_get_target (wcr); \
+   cairo_surface_t * out_s = cairo_surface_create_similar (window_surface, content, width, height); \
+   cairo_destroy (wcr); \
+   out_s; \
+})
+#define gdk_window_create_similar_image_surface(gdksurf,format,width,height,scale) ({ \
+   cairo_t * wcr = gdk_cairo_create (gdksurf); \
+   cairo_surface_t * window_surface = cairo_get_target (wcr); \
+   cairo_surface_t * out_s = cairo_surface_create_similar (window_surface, CAIRO_CONTENT_COLOR_ALPHA, width, height); \
+   cairo_destroy (wcr); \
+   out_s; \
+})
+#endif
+
+
+// GTK < 2.20
+#if ! GTK_CHECK_VERSION (2, 20, 0)
+#define gtk_widget_get_mapped(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_MAPPED) != 0)
+#define gtk_widget_get_realized(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_REALIZED) != 0)
+#define gtk_window_get_window_type(window) (GTK_WINDOW(window)->type)
+#define gtk_widget_get_requisition(w,r) (*(r) = GTK_WIDGET(w)->requisition)
+#define gtk_widget_set_mapped(w,yes) { \
+   if (yes) GTK_WIDGET_SET_FLAGS(w,GTK_MAPPED); \
+   else GTK_WIDGET_UNSET_FLAGS(w,GTK_MAPPED); \
+}
+#define gtk_widget_set_realized(w,yes) { \
+   if (yes) GTK_WIDGET_SET_FLAGS(w,GTK_REALIZED); \
+   else GTK_WIDGET_UNSET_FLAGS(w,GTK_REALIZED); \
+}
+#define gtk_range_get_slider_size_fixed(range) (GTK_RANGE(range)->slider_size_fixed)
+#define gtk_range_get_min_slider_size(range) (GTK_RANGE(range)->min_slider_size)
+#define gtk_entry_get_text_window(entry) (GTK_ENTRY(entry)->text_area)
+#endif
+
+
+// GTK < 2.18
+#if ! GTK_CHECK_VERSION (2, 18, 0)
+#define gtk_widget_get_state(wid) (GTK_WIDGET (wid)->state)
+#define gtk_widget_is_toplevel(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_TOPLEVEL) != 0)
+#define gtk_widget_get_has_window(wid) !((GTK_WIDGET_FLAGS (wid) & GTK_NO_WINDOW) != 0)
+#define gtk_widget_get_visible(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_VISIBLE) != 0)
+#define gtk_widget_is_drawable(wid)  (GTK_WIDGET_VISIBLE (wid) && GTK_WIDGET_MAPPED (wid))
+#define gtk_widget_get_sensitive(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_SENSITIVE) != 0)
+#define gtk_widget_get_can_focus(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_CAN_FOCUS) != 0)
+#define gtk_widget_has_focus(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_HAS_FOCUS) != 0)
+#define gtk_widget_get_can_default(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_CAN_DEFAULT) != 0)
+#define gtk_widget_get_receives_default(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_RECEIVES_DEFAULT) != 0)
+#define gtk_widget_has_default(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_HAS_DEFAULT) != 0)
+#define gtk_widget_has_grab(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_HAS_GRAB) != 0)
+#define gtk_widget_get_app_paintable(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_APP_PAINTABLE) != 0)
+#define gtk_widget_get_double_buffered(wid) ((GTK_WIDGET_FLAGS (wid) & GTK_DOUBLE_BUFFERED) != 0)
+#define gtk_widget_set_allocation(w,alloc) (GTK_WIDGET(w)->allocation = *(alloc))
+#define gtk_widget_get_allocation(w,alloc) (*(alloc) = GTK_WIDGET(w)->allocation)
+#define gtk_widget_set_can_default(w,yes) { \
+   if (yes) GTK_WIDGET_SET_FLAGS(w,GTK_CAN_DEFAULT); \
+   else GTK_WIDGET_UNSET_FLAGS(w,GTK_CAN_DEFAULT); \
+}
+#define gtk_widget_set_can_focus(w,yes) { \
+   if (yes) GTK_WIDGET_SET_FLAGS(w,GTK_CAN_FOCUS); \
+   else GTK_WIDGET_UNSET_FLAGS(w,GTK_CAN_FOCUS); \
+}
+#define gtk_widget_set_has_window(w,yes) { \
+   if (yes) GTK_WIDGET_UNSET_FLAGS(w,GTK_NO_WINDOW); \
+   else GTK_WIDGET_SET_FLAGS(w,GTK_NO_WINDOW); \
+}
+#define gtk_widget_set_visible(w,yes) { \
+   if (yes) gtk_widget_show(w); \
+   else gtk_widget_hide(w); \
+}
+#define gtk_range_get_flippable(range) (GTK_RANGE(range)->flippable)
+#define gdk_window_is_destroyed(w) (GDK_WINDOW_DESTROYED (GDK_WINDOW(w)))
+#endif
+
+
+// GTK < 2.16
+#if ! GTK_CHECK_VERSION (2, 16, 0)
+#define gtk_status_icon_set_tooltip_text(icon,text) gtk_status_icon_set_tooltip(icon,text)
+#define gtk_menu_item_get_label(i) (gtk_label_get_label (GTK_LABEL (GTK_BIN (i)->child)))
+#define gtk_menu_item_set_label(i,label) gtk_label_set_label(GTK_LABEL(GTK_BIN(i)->child), (label) ? label : "")
+#define gtk_menu_item_get_use_underline(i) (gtk_label_get_use_underline (GTK_LABEL (GTK_BIN (i)->child)))
+#define gtk_status_icon_set_tooltip_text gtk_status_icon_set_tooltip
+#endif
+
+
+// GTK < 2.14
+#if ! GTK_CHECK_VERSION (2, 14, 0)
+#define gtk_dialog_get_action_area(dialog)    (GTK_DIALOG(dialog)->action_area)
+#define gtk_dialog_get_content_area(dialog)   (GTK_DIALOG(dialog)->vbox)
+#define gtk_widget_get_window(widget)         (GTK_WIDGET(widget)->window)
+#define gtk_window_get_default_widget(window) (GTK_WINDOW(window)->default_widget)
+#define gtk_menu_item_get_accel_path(i)       (GTK_MENU_ITEM(i)->accel_path)
+#define gtk_menu_get_accel_path(menu)         (GTK_MENU(menu)->accel_path)
+#define gtk_message_dialog_get_image(m)       (GTK_MESSAGE_DIALOG(m)->image)
+#define gtk_entry_get_overwrite_mode(e)       (GTK_ENTRY(e)->overwrite_mode)
+#endif
+
+
+/* ================================================== */
+/*                     GDK KEYS                       */
+/* ================================================== */
+
+#ifndef GDK_KEY_a
+#	define GDK_KEY_Control_R GDK_Control_R
+#	define GDK_KEY_Control_L GDK_Control_L
+#	define GDK_KEY_Shift_R GDK_Shift_R
+#	define GDK_KEY_Shift_L GDK_Shift_L
+#	define GDK_KEY_Alt_R GDK_Alt_R
+#	define GDK_KEY_Alt_L GDK_Alt_L
+#	define GDK_KEY_Tab GDK_Tab
+#	define GDK_KEY_space GDK_space
+#	define GDK_KEY_Up GDK_Up
+#	define GDK_KEY_Down GDK_Down
+#	define GDK_KEY_Right GDK_Right
+#	define GDK_KEY_Left GDK_Left
+#	define GDK_KEY_Return GDK_Return
+#	define GDK_KEY_exclam GDK_exclam
+#	define GDK_KEY_BackSpace GDK_BackSpace
+#	define GDK_KEY_Home GDK_Home
+#	define GDK_KEY_End GDK_End
+#	define GDK_KEY_Escape GDK_Escape
+#	define GDK_KEY_a GDK_a
+#	define GDK_KEY_A GDK_A
+#	define GDK_KEY_b GDK_b
+#	define GDK_KEY_B GDK_B
+#	define GDK_KEY_c GDK_c
+#	define GDK_KEY_C GDK_C
+#	define GDK_KEY_d GDK_d
+#	define GDK_KEY_D GDK_D
+#	define GDK_KEY_e GDK_e
+#	define GDK_KEY_E GDK_E
+#	define GDK_KEY_f GDK_F
+#	define GDK_KEY_g GDK_g
+#	define GDK_KEY_G GDK_G
+#	define GDK_KEY_h GDK_h
+#	define GDK_KEY_H GDK_H
+#	define GDK_KEY_i GDK_i
+#	define GDK_KEY_I GDK_I
+#	define GDK_KEY_j GDK_j
+#	define GDK_KEY_J GDK_J
+#	define GDK_KEY_k GDK_k
+#	define GDK_KEY_K GDK_K
+#	define GDK_KEY_l GDK_l
+#	define GDK_KEY_L GDK_L
+#	define GDK_KEY_m GDK_m
+#	define GDK_KEY_M GDK_M
+#	define GDK_KEY_n GDK_n
+#	define GDK_KEY_N GDK_N
+#	define GDK_KEY_o GDK_o
+#	define GDK_KEY_O GDK_O
+#	define GDK_KEY_p GDK_p
+#	define GDK_KEY_P GDK_P
+#	define GDK_KEY_q GDK_q
+#	define GDK_KEY_Q GDK_Q
+#	define GDK_KEY_r GDK_r
+#	define GDK_KEY_R GDK_R
+#	define GDK_KEY_s GDK_s
+#	define GDK_KEY_S GDK_S
+#	define GDK_KEY_t GDK_t
+#	define GDK_KEY_T GDK_T
+#	define GDK_KEY_u GDK_u
+#	define GDK_KEY_U GDK_U
+#	define GDK_KEY_v GDK_v
+#	define GDK_KEY_V GDK_V
+#	define GDK_KEY_w GDK_w
+#	define GDK_KEY_W GDK_W
+#	define GDK_KEY_x GDK_x
+#	define GDK_KEY_X GDK_X
+#	define GDK_KEY_y GDK_y
+#	define GDK_KEY_Y GDK_Y
+#	define GDK_KEY_z GDK_z
+#	define GDK_KEY_Z GDK_Z
+#	define GDK_KEY_exclam GDK_exclam
+#	define GDK_KEY_F1 GDK_F1
+#	define GDK_KEY_F2 GDK_F2
+#	define GDK_KEY_F3 GDK_F3
+#	define GDK_KEY_F4 GDK_F4
+#	define GDK_KEY_F5 GDK_F5
+#	define GDK_KEY_F6 GDK_F6
+#	define GDK_KEY_F7 GDK_F7
+#	define GDK_KEY_F8 GDK_F8
+#	define GDK_KEY_F9 GDK_F9
+#	define GDK_KEY_F10 GDK_F10
+#	define GDK_KEY_F11 GDK_F11
+#	define GDK_KEY_F12 GDK_F12
+#	define GDK_KEY_KP_Home GDK_KP_Home
+#	define GDK_KEY_KP_Page_Up GDK_KP_Page_Up
+#	define GDK_KEY_KP_End GDK_KP_End
+#	define GDK_KEY_KP_Page_Down GDK_KP_Page_Down
+#	define GDK_KEY_KP_Space GDK_KP_Space
+#	define GDK_KEY_KP_Enter GDK_KP_Enter
+#	define GDK_KEY_KP_Left GDK_KP_Left
+#	define GDK_KEY_KP_Right GDK_KP_Right
+#	define GDK_KEY_KP_Up GDK_KP_Up
+#	define GDK_KEY_KP_Down GDK_KP_Down
+#endif
+
+
+// CAIRO < 1.10
+#if CAIRO_VERSION < CAIRO_VERSION_ENCODE(1, 10, 0)
+#define cairo_region_t         GdkRegion
+#define cairo_rectangle_int_t  GdkRectangle
+#define cairo_region_create    gdk_region_new
+#define cairo_region_copy      gdk_region_copy
+#define cairo_region_destroy   gdk_region_destroy
+#define cairo_region_create_rectangle gdk_region_rectangle
+#define cairo_region_get_extents gdk_region_get_clipbox
+#define cairo_region_is_empty  gdk_region_empty
+#define cairo_region_equal     gdk_region_empty
+#define cairo_region_contains_point gdk_region_point_in
+#define cairo_region_contains_rectangle gdk_region_rect_in
+#define cairo_region_translate gdk_region_rect_in
+#define cairo_region_union_rectangle gdk_region_union_with_rect
+#define cairo_region_intersect gdk_region_intersect
+#define cairo_region_union     gdk_region_union
+#define cairo_region_subtract  gdk_region_subtract
+#define cairo_region_xor       gdk_region_xor
+//#define cairo_region_num_rectangles / cairo_region_get_rectangle  gdk_region_get_rectangles
+#endif
+
+
+// PANGO
+#ifndef PANGO_WEIGHT_MEDIUM
+#define PANGO_WEIGHT_MEDIUM 500
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GTKCOMPAT_H */

--- a/src/gtkutils.c
+++ b/src/gtkutils.c
@@ -7,10 +7,11 @@
  */
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
+#include "gtkcompat.h"
 
 gboolean ut_key_pressed_cb(GtkWidget *widget, GdkEventKey *event)
 {
-   if(widget && event && event->keyval == GDK_Escape) {
+   if(widget && event && event->keyval == GDK_KEY_Escape) {
       gtk_widget_destroy(widget);
       return TRUE;
    }
@@ -73,7 +74,7 @@ GtkWidget * gtkutil_frame_vbox (char * label, GtkWidget * parent_box)
    frame = gtk_frame_new (label);
    gtk_box_pack_start (GTK_BOX (parent_box), frame, FALSE, FALSE, 0);
 
-   GtkWidget * frame_vbox = gtk_vbox_new (FALSE, 5);
+   GtkWidget * frame_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
    gtk_container_add (GTK_CONTAINER (frame), frame_vbox);
    /* padding */
    gtk_container_set_border_width (GTK_CONTAINER (frame_vbox), 5);
@@ -112,7 +113,7 @@ GtkWidget *ut_spin_button_new(gchar *label, gint min, gint max, gint val, GtkWid
    GtkAdjustment *adj;
    GtkWidget *button, *hbox, *labelw;
 
-   hbox = gtk_hbox_new(FALSE, 0);
+   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
    gtk_box_pack_start(GTK_BOX(parent), hbox, TRUE, TRUE, 0);
 
    labelw = gtk_label_new(label);

--- a/src/halloffame.c
+++ b/src/halloffame.c
@@ -58,7 +58,6 @@ void show_hall_of_fame (GtkWidget *widget, gpointer data, struct score_board b[1
    }
 
    tv = gtk_tree_view_new_with_model (GTK_TREE_MODEL(store));
-   gtk_tree_view_set_rules_hint (GTK_TREE_VIEW(tv), TRUE);
    gtk_tree_selection_set_mode (gtk_tree_view_get_selection(GTK_TREE_VIEW(tv)), GTK_SELECTION_BROWSE);
    g_object_unref (G_OBJECT(store));
    renderer = gtk_cell_renderer_text_new ();

--- a/src/mainmenu.c
+++ b/src/mainmenu.c
@@ -76,7 +76,6 @@ void menu_get_main(GtkWidget *window, GtkWidget **menubar)
    gtk_action_group_set_translate_func(_action_group, _menu_translate, NULL, NULL);
    gtk_action_group_add_actions(_action_group, _menu_entries, G_N_ELEMENTS(_menu_entries), window);
    _ui_manager = gtk_ui_manager_new();
-   gtk_ui_manager_set_add_tearoffs(_ui_manager, 1);
    gtk_ui_manager_insert_action_group(_ui_manager, _action_group, 0);
    accel_group = gtk_ui_manager_get_accel_group(_ui_manager);
    gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -107,26 +107,26 @@ gint _user_action_event(GtkWidget *w, GdkEvent *ev)
    }
 
    if (ev->type == GDK_KEY_PRESS) {
-      if (ev->key.keyval == GDK_Left || ev->key.keyval == GDK_KP_Left) {
+      if (ev->key.keyval == GDK_KEY_Left || ev->key.keyval == GDK_KEY_KP_Left) {
          move_pointer(DIR_LEFT);
-      } else if (ev->key.keyval == GDK_Right || ev->key.keyval == GDK_KP_Right) {
+      } else if (ev->key.keyval == GDK_KEY_Right || ev->key.keyval == GDK_KEY_KP_Right) {
          move_pointer(DIR_RIGHT);
-      } else if (ev->key.keyval == GDK_Up || ev->key.keyval == GDK_KP_Up) {
+      } else if (ev->key.keyval == GDK_KEY_Up || ev->key.keyval == GDK_KEY_KP_Up) {
          move_pointer(DIR_UP);
-      } else if (ev->key.keyval == GDK_Down || ev->key.keyval == GDK_KP_Down) {
+      } else if (ev->key.keyval == GDK_KEY_Down || ev->key.keyval == GDK_KEY_KP_Down) {
          move_pointer(DIR_DOWN);
-      } else if (ev->key.keyval == GDK_KP_Home) {
+      } else if (ev->key.keyval == GDK_KEY_KP_Home) {
          move_pointer(DIR_UP_LEFT);
-      } else if (ev->key.keyval == GDK_KP_Page_Up) {
+      } else if (ev->key.keyval == GDK_KEY_KP_Page_Up) {
          move_pointer(DIR_UP_RIGHT);
-      } else if (ev->key.keyval == GDK_KP_End) {
+      } else if (ev->key.keyval == GDK_KEY_KP_End) {
          move_pointer(DIR_DOWN_LEFT);
-      } else if (ev->key.keyval == GDK_KP_Page_Down) {
+      } else if (ev->key.keyval == GDK_KEY_KP_Page_Down) {
          move_pointer(DIR_DOWN_RIGHT);
-      } else if (ev->key.keyval == GDK_Return ||
-         ev->key.keyval == GDK_KP_Space ||
-         ev->key.keyval == GDK_KP_Enter ||
-         ev->key.keyval == GDK_space) {
+      } else if (ev->key.keyval == GDK_KEY_Return ||
+         ev->key.keyval == GDK_KEY_KP_Space ||
+         ev->key.keyval == GDK_KEY_KP_Enter ||
+         ev->key.keyval == GDK_KEY_space) {
          if (is_actions_locked()) {
             return FALSE;
          }
@@ -175,36 +175,37 @@ void mw_create(gint da_width, gint da_height)
       g_error_free (error);
    }
 
-   vbox = gtk_vbox_new (FALSE, 5);
+   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
    gtk_container_add (GTK_CONTAINER(mainwin), vbox);
 
    menu_get_main (mainwin, &menubar);
    menu_set_sensitive_undo (FALSE);
    gtk_box_pack_start (GTK_BOX(vbox), menubar, FALSE, TRUE, 0);
 
-   hbox = gtk_hbox_new (FALSE, 0);
+   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
    _hi_score_label = gtk_label_new ("");
    gtk_box_pack_start (GTK_BOX(hbox), _hi_score_label, FALSE, FALSE, 5);
    _user_score_label = gtk_label_new("");
    gtk_box_pack_end (GTK_BOX(hbox), _user_score_label, FALSE, FALSE, 5);
    gtk_box_pack_start (GTK_BOX(vbox), GTK_WIDGET(hbox), FALSE, FALSE, 0);
 
-   _small_balls_box = gtk_hbox_new(TRUE, 0);
+   _small_balls_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+   gtk_box_set_homogeneous (GTK_BOX (_small_balls_box), TRUE);
    gtk_box_pack_start (GTK_BOX(hbox), _small_balls_box, TRUE, FALSE, 0);
 
-   hbox1 = gtk_hbox_new (FALSE, 0);
+   hbox1 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
    timer_label = gtk_label_new (NULL);
    gtk_box_pack_start (GTK_BOX(hbox1), timer_label, TRUE, TRUE, 5);
    g_timeout_add(250, _countdown_timer, timer_label);
    gtk_box_pack_start (GTK_BOX(vbox), GTK_WIDGET(hbox1), FALSE, FALSE, 0);
 
-   drawing_area_box = gtk_hbox_new(FALSE, 0);
+   drawing_area_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
    gtk_box_pack_start (GTK_BOX(vbox), drawing_area_box, FALSE, FALSE, 10);
    _drawing_area = gtk_drawing_area_new();
    gtk_widget_set_size_request (_drawing_area, da_width, da_height);
    gtk_box_pack_start (GTK_BOX(drawing_area_box), _drawing_area, TRUE, FALSE, 10);
    gtk_widget_set_events (_drawing_area, GDK_EXPOSURE_MASK | GDK_BUTTON_PRESS_MASK | GDK_KEY_PRESS_MASK | GDK_POINTER_MOTION_MASK);
-   g_signal_connect (G_OBJECT(_drawing_area), "expose_event", G_CALLBACK(expose_event), NULL);
+   g_signal_connect (G_OBJECT(_drawing_area), GTKCOMPAT_DRAW_SIGNAL, G_CALLBACK(boardw_draw_event), NULL);
    g_signal_connect (G_OBJECT(_drawing_area), "button_press_event", G_CALLBACK(_user_action_event), NULL);
    g_signal_connect (G_OBJECT(_drawing_area), "motion_notify_event", G_CALLBACK(_user_action_event), NULL);
    /* FIXME: imho catching keypress on whole window is stupid... */

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -163,8 +163,8 @@ void preferences_dialog (void)
 
    theme_scrolled_window = gtk_scrolled_window_new (NULL, NULL);
    gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW(theme_scrolled_window), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW(theme_scrolled_window), GTK_SHADOW_ETCHED_IN);
    gtk_box_pack_start (GTK_BOX(vbox), theme_scrolled_window, FALSE, FALSE, 5);
+   gtk_widget_set_size_request (theme_scrolled_window, -1, 150);
 
    store = gtk_list_store_new (1, G_TYPE_STRING);
    for (i = 0, st = 0; themelist[i] != NULL; i++) {
@@ -178,9 +178,7 @@ void preferences_dialog (void)
    g_free (themelist);
 
    buttons[PR_THEME_LIST] = gtk_tree_view_new_with_model (GTK_TREE_MODEL(store));
-   gtk_widget_set_size_request (buttons[PR_THEME_LIST], -1, 150);
    g_object_unref (G_OBJECT(store));
-   gtk_tree_view_set_rules_hint (GTK_TREE_VIEW(buttons[PR_THEME_LIST]), TRUE);
    gtk_tree_view_set_search_column (GTK_TREE_VIEW(buttons[PR_THEME_LIST]), 0);
    gtk_tree_selection_set_mode (gtk_tree_view_get_selection(GTK_TREE_VIEW(buttons[PR_THEME_LIST])), GTK_SELECTION_BROWSE);
    gtk_container_add (GTK_CONTAINER(theme_scrolled_window), buttons[PR_THEME_LIST]);

--- a/src/rules.c
+++ b/src/rules.c
@@ -20,7 +20,7 @@ void show_rules (GtkWidget *widget, gpointer data)
    dialog = gtkutil_dialog_new (_("Rules"), main_window, TRUE, &main_vbox);
    vbox   = gtkutil_frame_vbox (_("Rules"), main_vbox);
 
-   hbox = gtk_hbox_new (FALSE, 0);
+   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
    gtk_box_pack_start (GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
 
    label = gtk_label_new (_("The standard play area of GtkBalls is a 9x9\n" \

--- a/src/savedialog.c
+++ b/src/savedialog.c
@@ -247,7 +247,6 @@ void save_load_game_dialog(gboolean is_save)
    free_gamelist(gamelist, num);
 
    treeview = gtk_tree_view_new_with_model (GTK_TREE_MODEL(store));
-   gtk_tree_view_set_rules_hint (GTK_TREE_VIEW(treeview), TRUE);
    gtk_tree_view_set_search_column (GTK_TREE_VIEW(treeview), 0);
    gtk_tree_selection_set_mode (gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview)), GTK_SELECTION_BROWSE);
    g_signal_connect (G_OBJECT(gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview))),
@@ -270,18 +269,16 @@ void save_load_game_dialog(gboolean is_save)
    column = gtk_tree_view_column_new_with_attributes (_("Score"), renderer, "text", 2, NULL);
    gtk_tree_view_append_column (GTK_TREE_VIEW(treeview), column);
 
-   if (iter.stamp == store->stamp) {
-      if (is_save) {
-         path = gtk_tree_model_get_path (GTK_TREE_MODEL(store), &iter);
-      } else {
-         path = gtk_tree_path_new_from_string ("0");
-      }
-      if (path) {
-         gtk_tree_selection_select_path (gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview)), path);
-         gtk_tree_view_set_cursor (GTK_TREE_VIEW(treeview), path, NULL, FALSE);
-         gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW(treeview), path, NULL, TRUE, 0, 0);
-         gtk_tree_path_free (path);
-      }
+   if (is_save) {
+      path = gtk_tree_model_get_path (GTK_TREE_MODEL(store), &iter);
+   } else {
+      path = gtk_tree_path_new_from_string ("0");
+   }
+   if (path) {
+      gtk_tree_selection_select_path (gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview)), path);
+      gtk_tree_view_set_cursor (GTK_TREE_VIEW(treeview), path, NULL, FALSE);
+      gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW(treeview), path, NULL, TRUE, 0, 0);
+      gtk_tree_path_free (path);
    }
    g_object_unref (G_OBJECT(store));
 


### PR DESCRIPTION
- added gtkcompat.h to keep compatibility with gtk2

- make gtk3 port compile

- gcc warnings: deprecated stuff is in mainmenu.c

GtkAction, Stock Items and GtkUIManager.
These are superseded by GMenu and GtkApplication, which is a major change, that makes sense if gtk4 support is to be added

- default to GTK3, fall back to GTK2
    
the gtk3 port will be compiled if gtk3 is available

gtk3: ./configure --prefix=/usr
gtk2: ./configure --prefix=/usr --enable-gtk2

ref #4